### PR TITLE
Fix the branch the code of conduct attribution directs to

### DIFF
--- a/pages/code-of-conduct.js
+++ b/pages/code-of-conduct.js
@@ -78,7 +78,7 @@ const COCText = () => (
             <h2>Attribution</h2>
             <p>
                 This Code of Conduct is adapted from the{" "}
-                <a href="https://github.com/adafruit/Adafruit_Community_Code_of_Conduct/blob/master/code-of-conduct.md">
+                <a href="https://github.com/adafruit/Adafruit_Community_Code_of_Conduct/blob/main/code-of-conduct.md">
                     Adafruit Community Code of Conduct.
                 </a>
             </p>


### PR DESCRIPTION
The main branch of the Adafruit code of conduct github has been changed from master to main. This pr changes to branch to main to avoid the popup:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/38714028/167322272-437e0195-f6e9-4cb0-be3a-16418afdf3a3.png">
