### PR TITLE
Update success.js - update discord tag on purchase complete

### DIFF
--- a/pages/success.js
+++ b/pages/success.js
@@ -22,7 +22,7 @@ const SessionDetails = ({ session }) => (
                 </b>{" "}
                 was successful, and a receipt has been sent to <b>{session.customer_details.email}</b>.
             </p>
-            <p>For any questions or concerns, please contact Oliver#0001 on Discord.</p>
+            <p>For any questions or concerns, please contact <b>oliver</b> on Discord.</p>
         </div>
     </div>
 );

--- a/pages/success.js
+++ b/pages/success.js
@@ -22,7 +22,7 @@ const SessionDetails = ({ session }) => (
                 </b>{" "}
                 was successful, and a receipt has been sent to <b>{session.customer_details.email}</b>.
             </p>
-            <p>For any questions or concerns, please contact <b>oliver</b> on Discord.</p>
+            <p>For any questions or concerns, please contact <b>@oliver</b> on Discord.</p>
         </div>
     </div>
 );


### PR DESCRIPTION
still uses old discord tag Oliver#0001 on the purchase success page, this fixes that to use the username system