### PR TITLE
Update people page with latest team data

### DIFF
--- a/pages/people.js
+++ b/pages/people.js
@@ -66,101 +66,98 @@ export default Team;
 export async function getStaticProps(context) {
     return {
         props: {
-            people:             [
+            people: [
                 [
                     {
                         name: "oliver",
                         image: "https://cdn.discordapp.com/avatars/398686833153933313/b785ad852db5f4eeceaee7c23740f849.png?size=1024",
-                        secondary: "Admin\nDevelopment Lead"
+                        secondary: "Admin\nDevelopment Lead",
                     },
-                    {
-                        name: "hyperbub",
-                        image: "https://cdn.discordapp.com/avatars/361759504422928387/a_b0441250052c4e1ea035f81097d924ce.gif?size=1024",
-                        secondary: "Admin\nHuman Resources Lead"
-                    },
-                    {
-                        name: "anoea",
-                        image: "https://cdn.discordapp.com/avatars/285861483412193280/684987d47b8a64c2e7b2dd6ad1712d80.png?size=1024",
-                        secondary: "Admin\nEvent Team Lead"
-                    }
                 ],
                 [
+                    {
+                        name: "foreboding",
+                        image: "https://cdn.discordapp.com/avatars/334155028170407949/f4f7f89f1163baa04ba11c3e6371888f.png?size=1024",
+                        secondary: "Admin\nDeveloper",
+                    },
                     {
                         name: "witherr.",
                         image: "https://cdn.discordapp.com/avatars/267550284979503104/e9cceaeb70ca9df3ef9899535439de98.png?size=1024",
-                        secondary: "Admin\nDeveloper"
-                    }
-                ],
-                [
-                    {
-                        name: "skiparoo",
-                        image: "https://cdn.discordapp.com/avatars/97104885337575424/602c68b9b032cec5bcda5ba826e0aae0.png?size=1024",
-                        secondary: "Developer"
-                    }
-                ],
-                [
-                    {
-                        name: "lesbians.",
-                        image: "https://cdn.discordapp.com/guilds/716390832034414685/users/517063415613751337/avatars/13325936e9b88201502901967f1beeb5.png?size=1024",
-                        secondary: "Server Admin\nModerator"
+                        secondary: "Admin\nDeveloper",
                     },
+                ],
+                [
                     {
                         name: "tazzy989",
                         image: "https://cdn.discordapp.com/avatars/1042169206692651038/ec2e13a27d230f8035606ab0c712deb1.png?size=1024",
-                        secondary: "Server Admin\nModerator"
+                        secondary: "Admin\nModerator",
                     },
+                ],
+                [
                     {
-                        name: "rusherhey",
-                        image: "https://cdn.discordapp.com/avatars/1282634614761848832/a1ea4555da2ab6b14c4e58cf7c9c7dbd.png?size=1024",
-                        secondary: "Bot Admin\nModerator"
+                        name: "anoea",
+                        image: "https://cdn.discordapp.com/avatars/285861483412193280/684987d47b8a64c2e7b2dd6ad1712d80.png?size=1024",
+                        secondary: "Event Team Lead\nModerator",
+                    },
+                ],
+                [
+                    {
+                        name: "varmonke",
+                        image: "https://cdn.discordapp.com/avatars/857103603130302514/6b34a23c82e4f49dcce2500d0408dc2a.png?size=1024",
+                        secondary: "Developer",
+                    },
+                ],
+                [
+                    {
+                        name: "frankmyocean",
+                        image: "https://cdn.discordapp.com/avatars/546492524366266369/5a1f4e905b7351709b96c6c999191618.png?size=1024",
+                        secondary: "Moderator\nEvent Team",
                     },
                     {
                         name: "bren.__.",
-                        image: "https://cdn.discordapp.com/avatars/336148113465278464/d72ac5f3b1cffeb1121800d74c017ab1.png?size=1024",
-                        secondary: "Bot Admin\nModerator"
-                    }
+                        image: "https://cdn.discordapp.com/avatars/336148113465278464/bc0adab136a4db602dc3721e87da9ec6.png?size=1024",
+                        secondary: "Moderator\nEvent Team",
+                    },
                 ],
                 [
                     {
-                        name: "somebluepigeon",
-                        image: "https://cdn.discordapp.com/avatars/711892049842012190/1487e550da4b8beb50e0da2c5c62e4b5.png?size=1024",
-                        secondary: "Moderator\nEvent Team"
+                        name: "djlo",
+                        image: "https://cdn.discordapp.com/avatars/1069709648598401145/5f72289ced453f53291a08549201965d.png?size=1024",
+                        secondary: "Moderator",
                     },
                     {
-                        name: "frankmyocean",
-                        image: "https://cdn.discordapp.com/avatars/546492524366266369/cc59956c246ada3de06bc90c2ceb1949.png?size=1024",
-                        secondary: "Moderator\nEvent Team"
-                    }
-                ],
-                [
-                    {
-                        name: "imperatorjordy",
-                        image: "https://cdn.discordapp.com/avatars/349284248840175617/b102c27457681426bedcb527528f1c18.png?size=1024",
-                        secondary: "Moderator"
+                        name: "mr_rio",
+                        image: "https://cdn.discordapp.com/avatars/720010802614239252/ea378abc63a8db617665b8ab49fef2ac.png?size=1024",
+                        secondary: "Moderator",
                     },
                     {
-                        name: "koh.na",
-                        image: "https://cdn.discordapp.com/avatars/1177693947481559090/f385b9d0f4f00afbe4e9c68f666961fa.png?size=1024",
-                        secondary: "Moderator"
+                        name: "zoro_tatsuya",
+                        image: "https://cdn.discordapp.com/avatars/710045949397041205/87cb09110e596dfd6e3a79be500317a5.png?size=1024",
+                        secondary: "Moderator",
                     },
                     {
-                        name: "ariesv78",
-                        image: "https://cdn.discordapp.com/avatars/898949618149249085/eb3a9385b2611aeb0e2593b2d23ecc71.png?size=1024",
-                        secondary: "Moderator"
-                    }
+                        name: "tokohyo",
+                        image: "https://cdn.discordapp.com/avatars/1177693947481559090/44248f56ccb46bda4cb700cf6119876c.png?size=1024",
+                        secondary: "Moderator",
+                    },
                 ],
                 [
                     {
                         name: "krisppykreme",
-                        image: "https://cdn.discordapp.com/avatars/182301129231695872/a_85dae865457503f884c0c7fec1a94609.gif?size=1024",
-                        secondary: "Event Team"
+                        image: "https://cdn.discordapp.com/avatars/182301129231695872/8dd082c7fbdbfb9b231b834f28d2dfa0.png?size=1024",
+                        secondary: "Event Team",
+                    },
+                    {
+                        name: "somebluepigeon",
+                        image: "https://cdn.discordapp.com/avatars/711892049842012190/6b3396bc3a0523df8a899c5b4f178509.png?size=1024",
+                        secondary: "Event Team",
                     },
                     {
                         name: "qydv",
-                        image: "https://cdn.discordapp.com/avatars/745825974880436294/7c99269530c3c548395e5daba087b090.png?size=1024",
-                        secondary: "Event Team"
-                    }
-                ]
+                        image: "https://cdn.discordapp.com/guilds/716390832034414685/users/745825974880436294/avatars/70ed47efb07e8b1912b6f8bbff01d0e9.png?size=1024",
+                        secondary: "Event Team",
+                    },
+                ],
             ],
         },
     };


### PR DESCRIPTION
## Summary

Replaces the team roster on the `/people` page with updated data. Changes include:

- **Added**: foreboding (Admin/Developer), varmonke (Developer), djlo, mr_rio, zoro_tatsuya, tokohyo (Moderators)
- **Removed**: hyperbub, skiparoo, lesbians., rusherhey, imperatorjordy, koh.na, ariesv78
- **Role updates**: tazzy989 → Admin/Moderator, anoea → Event Team Lead/Moderator, bren.__. → Moderator/Event Team, somebluepigeon → Event Team
- **Updated avatar URLs** for several existing members (bren.__., krisppykreme, frankmyocean, somebluepigeon, qydv)
- **Section grouping reorganized** (oliver now in solo section; foreboding + witherr. grouped together; etc.)
- Minor formatting cleanup via Prettier (trailing commas)

## Review & Testing Checklist for Human

- [ ] **Verify roster accuracy**: Cross-check that the added/removed/updated members and their roles match the intended team changes
- [ ] **Check avatar images load**: Visit the `/people` page and confirm all avatar images render correctly — several URLs changed, including qydv switching to a guild-specific avatar URL
- [ ] **Verify section grouping**: Confirm the visual grouping/ordering of team members on the page looks correct (sections control how members are randomized together)

### Notes
- Data was provided by the user as a Python list and converted to the existing JS format in `getStaticProps`
- No logic changes — only the static data array was replaced

Link to Devin session: https://app.devin.ai/sessions/18687a1eda84442c9363db993e43089a
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/poketwo.net/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
